### PR TITLE
Fetched rockets data from Rockets API

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - **[Setup linters for React/Redux]**
 - **[Setup React Bootstrap]**
 - **[Setup React Router & NavLinks]**
+- **[Fetch Rockets data form Rockets API]**
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -28,7 +28,7 @@ const Rockets = () => {
                     <span />
                     {rocket.description}
                   </p>
-                  <button className="button" type="button"> Reserve</button>
+                  <button className="button" type="button">Reserve</button>
                 </div>
               </section>
             ))

--- a/src/components/Rockets.jsx
+++ b/src/components/Rockets.jsx
@@ -1,10 +1,40 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import FetchRockets from '../redux/rockets/fetchRockets';
 
-const Rockets = () => (
-  <>
-    <h1>Rockets</h1>
-    <h2>Under Construction</h2>
-  </>
-);
+const Rockets = () => {
+  const { rockets, status, error } = useSelector((state) => state.rockets);
+  const Dispatch = useDispatch();
+  useEffect(() => {
+    Dispatch(FetchRockets());
+  }, [Dispatch]);
+  if (status) {
+    return true;
+  }
+  if (error) {
+    return 'there is an error';
+  }
+  return (
+    <div className="topContainer">
+      {
+            rockets.map((rocket) => (
+              <section className="Space" key={rocket.id}>
+                <div className="img">
+                  <img src={rocket.rocket_flickr_images} alt="" />
+                </div>
+                <div className="details">
+                  <h2>{rocket.rocket_name}</h2>
+                  <p>
+                    <span />
+                    {rocket.description}
+                  </p>
+                  <button className="button" type="button"> Reserve</button>
+                </div>
+              </section>
+            ))
+        }
+    </div>
+  );
+};
 
 export default Rockets;

--- a/src/redux/rockets/fetchRockets.js
+++ b/src/redux/rockets/fetchRockets.js
@@ -1,0 +1,15 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const FetchRockets = createAsyncThunk('get/rockets', async () => {
+  const rockets = await axios.get('https://api.spacexdata.com/v3/rockets');
+  const { data } = rockets;
+  return data.map((rocket) => ({
+    id: rocket.id,
+    rocket_name: rocket.rocket_name,
+    description: rocket.description,
+    rocket_images: rocket.flickr_images,
+  }));
+});
+
+export default FetchRockets;

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -1,9 +1,21 @@
 import { createSlice } from '@reduxjs/toolkit';
+import FetchRockets from './fetchRockets';
 
+const initialState = {
+  rockets: [],
+};
 const rocketsSlice = createSlice({
   name: 'rockets',
-  initialState: [],
+  initialState,
   reducers: {},
+  extraReducers(builder) {
+    builder
+      .addCase(FetchRockets.fulfilled, (state, action) => ({
+        ...state,
+        rockets: action.payload,
+        status: false,
+      }));
+  },
 });
 
 export default rocketsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
+import rocketsSlice from './rockets/rocketsSlice';
 
 const store = configureStore({
-  reducer: {},
+  reducer: {
+    rockets: rocketsSlice,
+  },
 });
 
 export default store;


### PR DESCRIPTION
### The following changes have been made to this PR:

- Fetch data from the Rockets endpoint (https://api.spacexdata.com/v3/rockets) when the application starts (as Rockets is the default view).
- Once the data are fetched, dispatch an action to store the selected data in Redux store:
1. id
2. rocket_name
3. rocket_type
4. flickr_images
- Updated Readme file